### PR TITLE
Change "$mount == undef" to "$share != undef"

### DIFF
--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -71,7 +71,7 @@ define nfs::client::mount (
 ){
 
   if $nfs_v4 == true {
-    if $mount == undef {
+    if $share != undef {
       $mountname = "${::nfs::nfs_v4_mount_root}/${share}"
     } else {
       $mountname = $mount
@@ -96,7 +96,7 @@ define nfs::client::mount (
       }
     }
   } else {
-    if $mount == undef {
+    if $share != undef {
       $mountname = $share
     } else {
       $mountname = $mount


### PR DESCRIPTION
Because $mount gets set to the namevar, it can never be undef and so the share parameter will never be used.  When used as specified in the README, the client mount exported from the server export definition always gets a namevar with spaces, and tries to use that as the mount name, yielding an error like this:

Error: Failed to apply catalog: Parameter name failed on Mount[shared /opt/sge by compute1.example.com on shared /opt/sge by head.example.com]: name must not contain whitespace: shared /opt/sge by head.example.com at /etc/puppet/environments/hpc/modules/nfs/manifests/client/mount.pp:115

The Puppet built-in Mount type is getting "shared /opt/sge by head.example.com" as its mount path and failing; note that this is the expected namevar for Nfs::Server::Export sharing /opt/sge on head.example.com.

Since nfs::server::export declares the exported Nfs::Client::Mount resource using the $share parameter instead of the $mount parameter, and $mount == $name and can't be undef, we need to look at whether or not share is undef.

Thanks for all your hard work on this module!