### PR TITLE
Fix non UTF-8 char

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,7 +91,7 @@ class nfs::params {
   $client_services_hasstatus  = true
   $server_service_hasrestart  = true
   $server_service_hasstatus   = true
-  # params with OS-specific values
+  # params with OS-specific values
   case "${::osfamily}-${::operatingsystemmajrelease}" {
     /^Debian/: {
       $client_idmapd_setting      = [ 'set NEED_IDMAPD yes' ]


### PR DESCRIPTION
It seems the '#' char is non UTF-8 which raises the following error on my
server:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER:
invalid byte sequence in US-ASCII at
/etc/puppet/environments/development/modules/forge/nfs/manifests/params.pp:1 on
node