### PR TITLE
some bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+##2015-01-13 - Release 0.0.11
+###Summary
+
+####Bugfixes
+- update client mount to use relative devicename to "fsid=root" in nfs v4
+- update client mount spec tests
+- fix https://github.com/derdanne/puppet-nfs/issues/19
+- update gentoo default $client_nfsv4_fstype to reflect syntax update in net-fs/nfs-utils
+
 ##2015-11-26 - Release 0.0.10
 ###Summary
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ maintaining his module actively anymore. It is stripped down to use only the cla
 and parametrized to act as a server, client or both with the parameters 'server_enabled'
 and 'client_enabled'. It also has some dependencies on newer stdlib functions like 'difference'.
 
-It supports the OS Families Ubuntu, Debian, Redhat and Gentoo. It supports also Strict Variables, so if you pass all 
+It supports the OS Families Ubuntu, Debian, Redhat, SUSE and Gentoo. It supports also Strict Variables, so if you pass all 
 OS specific parameters correctly it should work on your preferred OS too. Feedback, bugreports, 
 and feature requests are always welcome, visit https://github.com/derdanne/puppet-nfs or send me an email.
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -136,7 +136,7 @@ class nfs::params {
       $client_idmapd_setting      = [ 'set NFS_NEEDED_SERVICES rpc.idmapd' ]
       $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,nfsvers=3,actimeo=3'
       $client_services            = { 'rpcbind' => {} }
-      $client_nfsv4_fstype        = 'nfs'
+      $client_nfsv4_fstype        = 'nfs4'
       $client_nfsv4_options       = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,nfsvers=4,actimeo=3'
       $client_nfsv4_services      = { 'rpcbind' => {}, 'rpc.idmapd' => {} }
       $server_nfsv4_servicehelper = 'rpc.idmapd'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "derdanne-nfs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "source": "https://github.com/derdanne/puppet-nfs.git",
   "author": "derdanne",
   "license": "Apache-2.0",
@@ -8,8 +8,8 @@
   "project_page": "https://github.com/derdanne/puppet-nfs",
   "issues_url": "https://github.com/derdanne/puppet-nfs/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.5.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 1.1.2"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0"},
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.2"}
   ],
   "tags": ["nfs", "nfs4", "exports", "mount", "mfc"],
   "operatingsystem_support": [

--- a/spec/defines/client_mount_spec.rb
+++ b/spec/defines/client_mount_spec.rb
@@ -19,7 +19,7 @@ describe 'nfs::client::mount', :type => 'define' do
 
     let(:params) {{ :server => '1.2.3.4' } }
     it { should contain_nfs__functions__mkdir('/srv/test') }
-    it { should contain_mount('shared /srv/test by example.com on /srv/test') }
+    it { should contain_mount('shared /srv/test by 1.2.3.4 on /srv/test') }
   end
 
   context "nfs_v4 => false, specified mountpoint and sharename" do
@@ -39,7 +39,7 @@ describe 'nfs::client::mount', :type => 'define' do
 
     let(:params) {{ :share => '/export/srv', :mount => '/srv', :server => '1.2.3.4' } }
     it { should contain_nfs__functions__mkdir('/srv') }
-    it { should contain_mount('shared /export/srv by example.com on /srv') }
+    it { should contain_mount('shared /export/srv by 1.2.3.4 on /srv') }
   end
 
   context "nfs_v4 => true, specified share" do
@@ -59,7 +59,7 @@ describe 'nfs::client::mount', :type => 'define' do
 
     let(:params) {{ :share => 'test', :server => '1.2.3.4' } }
     it { should contain_nfs__functions__mkdir('/srv/test') }
-    it { should contain_mount('shared /srv/test by example.com on /srv/test') }
+    it { should contain_mount('shared /test by 1.2.3.4 on /srv/test') }
   end
 
   context "nfs_v4 => true, minimal arguments" do
@@ -79,7 +79,7 @@ describe 'nfs::client::mount', :type => 'define' do
 
     let(:params) {{ :server => '1.2.3.4' } }
     it { should contain_nfs__functions__mkdir('/srv/test') }
-    it { should contain_mount('shared /srv/test by example.com on /srv/test') }
+    it { should contain_mount('shared /test by 1.2.3.4 on /srv/test') }
   end
 
   context "nfs_v4 => true, non-default mountpoints" do
@@ -99,6 +99,6 @@ describe 'nfs::client::mount', :type => 'define' do
 
     let(:params) {{ :share => 'test', :server => '1.2.3.4' } }
     it { should contain_nfs__functions__mkdir('/opt/sample') }
-    it { should contain_mount('shared /srv/test by example.com on /opt/sample') }
+    it { should contain_mount('shared /test by 1.2.3.4 on /opt/sample') }
   end
 end


### PR DESCRIPTION
update client mount to use relative devicename to "fsid=root" in nfs v4
update client mount spec tests
fix https://github.com/derdanne/puppet-nfs/issues/19
update gentoo default $client_nfsv4_fstype to reflect syntax update in net-fs/nfs-utils