### PR TITLE
[FIX] Debian calls the idmapd service nfs-common

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -101,7 +101,7 @@ class nfs::params {
       $client_nfsv4_fstype        = 'nfs4'
       $client_nfsv4_options       = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
       $client_nfsv4_services      = { 'rpcbind' => {}, 'idmapd' => {} }
-      $server_nfsv4_servicehelper = 'idmapd'
+      $server_nfsv4_servicehelper = 'nfs-common'
       $server_service_name        = 'nfs-kernel-server'
     }
     'RedHat-7': {


### PR DESCRIPTION
This is a very quick and easy fix for Debian Jessie. I checked with apt-file in an old Wheezy install and they call it nfs-common, too.