### PR TITLE
add a param server_service_restart_cmd to allow overriding restart fo…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,9 @@
 # [*server_service_hasstatus*]
 #   Boolean. It defines the service parameter hasstatus for nfs server service.
 #
+# [*server_service_restart_cmd*]
+#   String. It defines the service parameter restart for nfs server service.
+#
 # [*server_nfsv4_servicehelper*]
 #   String. It defines the service helper like idmapd for servers configured with
 #   nfs version 4.
@@ -157,6 +160,7 @@ class nfs(
   $server_service_enable        = true,
   $server_service_hasrestart    = $::nfs::params::server_service_hasrestart,
   $server_service_hasstatus     = $::nfs::params::server_service_hasstatus,
+  $server_service_restart_cmd   = $::nfs::params::server_service_restart_cmd,
   $server_nfsv4_servicehelper   = $::nfs::params::server_nfsv4_servicehelper,
   $client_services              = $::nfs::params::client_services,
   $client_nfsv4_services        = $::nfs::params::client_nfsv4_services,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,6 +208,7 @@ class nfs(
   validate_bool($server_service_enable)
   validate_bool($server_service_hasrestart)
   validate_bool($server_service_hasstatus)
+  validate_string($server_service_restart_cmd)
   validate_string($server_nfsv4_servicehelper)
   validate_hash($client_services)
   validate_hash($client_nfsv4_services)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,6 +92,7 @@ class nfs::params {
   $client_services_hasstatus  = true
   $server_service_hasrestart  = true
   $server_service_hasstatus   = true
+  $server_service_restart_cmd = undef
   #params with OS-specific values
   case $::osfamily {
     'Debian': {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -23,6 +23,7 @@ class nfs::server::service {
       enable     => $::nfs::server_service_enable,
       hasrestart => $::nfs::server_service_hasrestart,
       hasstatus  => $::nfs::server_service_hasstatus,
+      restart    => $::nfs::server_service_restart_cmd,
       subscribe  => [ Concat[$::nfs::exports_file], Augeas[$::nfs::idmapd_file] ],
     }
     if $::nfs::server_nfsv4_servicehelper != undef {
@@ -40,6 +41,7 @@ class nfs::server::service {
     enable     => $::nfs::server_service_enable,
     hasrestart => $::nfs::server_service_hasrestart,
     hasstatus  => $::nfs::server_service_hasstatus,
+    restart    => $::nfs::server_service_restart_cmd,
     subscribe  => Concat[$::nfs::exports_file],
     }
   }

--- a/spec/defines/client_mount_spec.rb
+++ b/spec/defines/client_mount_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nfs::client::mount', type: 'define' do
   context 'nfs_v4 => false, minimal arguments' do
-    let(:facts) {{
+    let(:facts) { {
       operatingsystem: 'Ubuntu',
       osfamily: 'Debian',
       operatingsystemmajrelease: '12.04',
@@ -12,7 +12,7 @@ describe 'nfs::client::mount', type: 'define' do
       is_pe: false,
       id: 'root',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }}
+    } }
     let(:title) { '/srv/test' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true,}' }
@@ -23,7 +23,7 @@ describe 'nfs::client::mount', type: 'define' do
   end
 
   context 'nfs_v4 => false, specified mountpoint and sharename' do
-    let(:facts) {{
+    let(:facts) { {
       operatingsystem: 'Ubuntu',
       osfamily: 'Debian',
       operatingsystemmajrelease: '12.04',
@@ -33,7 +33,7 @@ describe 'nfs::client::mount', type: 'define' do
       is_pe: false,
       id: 'root',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }}
+    } }
     let(:title) { 'Import /srv' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true,}' }
@@ -44,7 +44,7 @@ describe 'nfs::client::mount', type: 'define' do
   end
 
   context 'nfs_v4 => true, specified share' do
-    let(:facts) {{
+    let(:facts) { {
       operatingsystem: 'Ubuntu',
       osfamily: 'Debian',
       operatingsystemmajrelease: '12.04',
@@ -54,7 +54,7 @@ describe 'nfs::client::mount', type: 'define' do
       is_pe: false,
       id: 'root',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }}
+    } }
     let(:title) { '/srv/test' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true, nfs_v4_client => true }' }
@@ -65,7 +65,7 @@ describe 'nfs::client::mount', type: 'define' do
   end
 
   context 'nfs_v4 => true, minimal arguments' do
-    let(:facts) {{
+    let(:facts) { {
       operatingsystem: 'Ubuntu',
       osfamily: 'Debian',
       operatingsystemmajrelease: '12.04',
@@ -75,7 +75,7 @@ describe 'nfs::client::mount', type: 'define' do
       is_pe: false,
       id: 'root',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }}
+    } }
     let(:title) { '/srv/test' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true, nfs_v4_client => true }' }
@@ -86,7 +86,7 @@ describe 'nfs::client::mount', type: 'define' do
   end
 
   context 'nfs_v4 => true, non-default mountpoints' do
-    let(:facts) {{
+    let(:facts) { {
       operatingsystem: 'Ubuntu',
       osfamily: 'Debian',
       operatingsystemmajrelease: '12.04',
@@ -96,7 +96,7 @@ describe 'nfs::client::mount', type: 'define' do
       is_pe: false,
       id: 'root',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }}
+    } }
     let(:title) { '/opt/sample' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true, nfs_v4_client => true }' }

--- a/spec/defines/server_export_spec.rb
+++ b/spec/defines/server_export_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nfs::server::export', type: 'define' do
   context 'nvs_v4 => false' do
-    let(:facts) {{
+    let(:facts) { {
       operatingsystem: 'Ubuntu',
       osfamily: 'Debian',
       operatingsystemmajrelease: '12.04',
@@ -11,7 +11,7 @@ describe 'nfs::server::export', type: 'define' do
       is_pe: false,
       id: 'root',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }}
+    } }
     let(:title) { '/srv/test' }
 
     let(:pre_condition) { 'class {"nfs": server_enabled => true,}' }
@@ -22,7 +22,7 @@ describe 'nfs::server::export', type: 'define' do
     end
   end
   context 'nvs_v4 => true' do
-    let(:facts) {{
+    let(:facts) { {
       operatingsystem: 'Ubuntu',
       osfamily: 'Debian',
       operatingsystemmajrelease: '12.04',
@@ -31,7 +31,7 @@ describe 'nfs::server::export', type: 'define' do
       is_pe: false,
       id: 'root',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }}
+    } }
     let(:title) { '/srv/test' }
     let(:pre_condition) { 'class {"nfs": server_enabled => true, nfs_v4 => true}' }
 


### PR DESCRIPTION
I added  an optional param server_service_restart_cmd that allows you to override the restart command that is passed through to the nfs service . When you don't give it a value it defaults to undef and the default restart command is used as it was before.

We use this for example so we can do an "exportfs -a" instead of a restart of the entire service.