### PR TITLE
set owner/group/mode of the exported directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'metadata-json-lint/rake_task'
 require 'puppet_blacksmith/rake_tasks'
 require 'voxpupuli/release/rake_tasks'
 require 'rubocop/rake_task'
-require 'puppet-strings/rake_tasks'
+require 'puppet-strings/tasks'
 
 RuboCop::RakeTask.new
 

--- a/manifests/functions/create_export.pp
+++ b/manifests/functions/create_export.pp
@@ -37,6 +37,10 @@ define nfs::functions::create_export (
       content => $line,
     }
 
-    ensure_resource( 'file', $name, { ensure => directory, } )
+    if ! defined(File[$name]) {
+      file { $name:
+        ensure => directory,
+      }
+    }
   }
 }

--- a/manifests/functions/create_export.pp
+++ b/manifests/functions/create_export.pp
@@ -11,6 +11,15 @@
 # [*ensure*]
 #   String. Sets if enabled or not.
 #
+# [*owner*]
+#   String. Sets the owner of the exported directory.
+#
+# [*group*]
+#   String. Sets the group of the exported directory.
+#
+# [*mode*]
+#   String. Sets the permissions of the exported directory.
+#
 # === Examples
 #
 # This Function should not be called directly.
@@ -28,6 +37,9 @@
 define nfs::functions::create_export (
   $clients,
   $ensure = 'present',
+  $owner  = undef,
+  $group  = undef,
+  $mode   = undef,
 ) {
   if $ensure != 'absent' {
     $line = "${name} ${clients}\n"
@@ -40,6 +52,9 @@ define nfs::functions::create_export (
     if ! defined(File[$name]) {
       file { $name:
         ensure => directory,
+        owner  => $owner,
+        group  => $group,
+        mode   => $mode,
       }
     }
   }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -34,7 +34,12 @@ class nfs::server::config {
       order   => 2,
     }
 
-    ensure_resource( 'file', $::nfs::server::nfs_v4_export_root, { ensure => directory, } )
+    if ! defined(File[$::nfs::server::nfs_v4_export_root]) {
+      file { $::nfs::server::nfs_v4_export_root:
+        ensure => directory,
+      }
+    }
+
     augeas { $::nfs::idmapd_file:
       context => "/files/${::nfs::idmapd_file}/General",
       lens    => 'Puppet.lns',

--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -39,6 +39,15 @@
 #   String. Sets the mountpoint the client will mount the exported resource mount on. If undef
 #   it defaults to the same path as on the server
 #
+# [*owner*]
+#   String. Sets the owner of the exported directory
+#
+# [*group*]
+#   String. Sets the group of the exported directory
+#
+# [*mode*]
+#   String. Sets the permissions of the exported directory.
+#
 # === Examples
 #
 # class { '::nfs':
@@ -78,6 +87,9 @@ define nfs::server::export(
   $options_nfs    = $::nfs::client_nfs_options,
   $bindmount      = undef,
   $nfstag         = undef,
+  $owner          = undef,
+  $group          = undef,
+  $mode           = undef,
 ) {
 
   if $nfs::server::nfs_v4 {
@@ -91,6 +103,9 @@ define nfs::server::export(
     nfs::functions::create_export { "${::nfs::server::nfs_v4_export_root}/${v4_export_name}":
       ensure  => $ensure,
       clients => $clients,
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
       require => Nfs::Functions::Nfsv4_bindmount[$name],
     }
 
@@ -122,6 +137,9 @@ define nfs::server::export(
     nfs::functions::create_export { $v3_export_name:
       ensure  => $ensure,
       clients => $clients,
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
     }
 
     @@nfs::client::mount { $mount_name:


### PR DESCRIPTION
replace ensure_resource again with if ! defined(File[$name])

ensure_resource creates duplicate resources when the resource is already
declared but has different attributes. With this commit, it will not create
duplicate resource when it is already declared