### PR TITLE
Migrate to Puppet 4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,69 +1,524 @@
+require: rubocop-rspec
 AllCops:
+  TargetRubyVersion: 1.9
   Include:
     - ./**/*.rb
   Exclude:
+    - files/**/*
     - vendor/**/*
+    - .vendor/**/*
     - pkg/**/*
     - spec/fixtures/**/*
+Lint/ConditionPosition:
+  Enabled: True
 
-# Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
-  Max: 328
+Lint/ElseLayout:
+  Enabled: True
 
-# 'Complexity' is very relative
-Metrics/PerceivedComplexity:
-  Enabled: false
+Lint/UnreachableCode:
+  Enabled: True
 
-# 'Complexity' is very relative
-Metrics/CyclomaticComplexity:
-  Enabled: false
+Lint/UselessComparison:
+  Enabled: True
 
-# 'Complexity' is very relative
-Metrics/AbcSize:
-  Enabled: false
+Lint/EnsureReturn:
+  Enabled: True
+
+Lint/HandleExceptions:
+  Enabled: True
+
+Lint/LiteralInCondition:
+  Enabled: True
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: True
+
+Lint/LiteralInInterpolation:
+  Enabled: True
+
+Style/HashSyntax:
+  Enabled: True
+
+Style/RedundantReturn:
+  Enabled: True
+
+Lint/AmbiguousOperator:
+  Enabled: True
+
+Lint/AssignmentInCondition:
+  Enabled: True
+
+Style/SpaceBeforeComment:
+  Enabled: True
+
+Style/AndOr:
+  Enabled: True
+
+Style/RedundantSelf:
+  Enabled: True
+
+Metrics/BlockLength:
+  Enabled: False
 
 # Method length is not necessarily an indicator of code quality
 Metrics/MethodLength:
-  Enabled: false
+  Enabled: False
 
 # Module length is not necessarily an indicator of code quality
 Metrics/ModuleLength:
-  Enabled: false
+  Enabled: False
+
+Style/WhileUntilModifier:
+  Enabled: True
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: True
+
+Security/Eval:
+  Enabled: True
+
+Lint/BlockAlignment:
+  Enabled: True
+
+Lint/DefEndAlignment:
+  Enabled: True
+
+Lint/EndAlignment:
+  Enabled: True
+
+Lint/DeprecatedClassMethods:
+  Enabled: True
+
+Lint/Loop:
+  Enabled: True
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: True
+
+Lint/RescueException:
+  Enabled: True
+
+Lint/StringConversionInInterpolation:
+  Enabled: True
+
+Lint/UnusedBlockArgument:
+  Enabled: True
+
+Lint/UnusedMethodArgument:
+  Enabled: True
+
+Lint/UselessAccessModifier:
+  Enabled: True
+
+Lint/UselessAssignment:
+  Enabled: True
+
+Lint/Void:
+  Enabled: True
+
+Style/AccessModifierIndentation:
+  Enabled: True
+
+Style/AccessorMethodName:
+  Enabled: True
+
+Style/Alias:
+  Enabled: True
+
+Style/AlignArray:
+  Enabled: True
+
+Style/AlignHash:
+  Enabled: True
+
+Style/AlignParameters:
+  Enabled: True
+
+Metrics/BlockNesting:
+  Enabled: True
+
+Style/AsciiComments:
+  Enabled: True
+
+Style/Attr:
+  Enabled: True
+
+Style/BracesAroundHashParameters:
+  Enabled: True
+
+Style/CaseEquality:
+  Enabled: True
+
+Style/CaseIndentation:
+  Enabled: True
+
+Style/CharacterLiteral:
+  Enabled: True
+
+Style/ClassAndModuleCamelCase:
+  Enabled: True
+
+Style/ClassAndModuleChildren:
+  Enabled: False
+
+Style/ClassCheck:
+  Enabled: True
 
 # Class length is not necessarily an indicator of code quality
 Metrics/ClassLength:
-  Enabled: false
+  Enabled: False
 
-# dealbreaker:
-Style/TrailingCommaInArguments:
-  Enabled: false
-Style/TrailingCommaInLiteral:
-  Enabled: false
-Style/ClosingParenthesisIndentation:
-  Enabled: false
+Style/ClassMethods:
+  Enabled: True
 
-Lint/AmbiguousRegexpLiteral:
-  Enabled: true
-Style/RegexpLiteral:
-  Enabled: true
+Style/ClassVars:
+  Enabled: True
+
+Style/WhenThen:
+  Enabled: True
+
 Style/WordArray:
-  Enabled: true
+  Enabled: True
 
-# this catches the cases of using `module` for parser functions, types, or
-# providers
-Style/ClassAndModuleChildren:
-  Enabled: false
+Style/UnneededPercentQ:
+  Enabled: True
+
+Style/Tab:
+  Enabled: True
+
+Style/SpaceBeforeSemicolon:
+  Enabled: True
+
+Style/TrailingBlankLines:
+  Enabled: True
+
+Style/SpaceInsideBlockBraces:
+  Enabled: True
+
+Style/SpaceInsideBrackets:
+  Enabled: True
+
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: True
+
+Style/SpaceInsideParens:
+  Enabled: True
+
+Style/LeadingCommentSpace:
+  Enabled: True
+
+Style/SpaceBeforeFirstArg:
+  Enabled: True
+
+Style/SpaceAfterColon:
+  Enabled: True
+
+Style/SpaceAfterComma:
+  Enabled: True
+
+Style/SpaceAfterMethodName:
+  Enabled: True
+
+Style/SpaceAfterNot:
+  Enabled: True
+
+Style/SpaceAfterSemicolon:
+  Enabled: True
+
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: True
+
+Style/SpaceAroundOperators:
+  Enabled: True
+
+Style/SpaceBeforeBlockBraces:
+  Enabled: True
+
+Style/SpaceBeforeComma:
+  Enabled: True
+
+Style/CollectionMethods:
+  Enabled: True
+
+Style/CommentIndentation:
+  Enabled: True
+
+Style/ColonMethodCall:
+  Enabled: True
+
+Style/CommentAnnotation:
+  Enabled: True
+
+# 'Complexity' is very relative
+Metrics/CyclomaticComplexity:
+  Enabled: False
+
+Style/ConstantName:
+  Enabled: True
 
 Style/Documentation:
-  Description: 'Document classes and non-namespace modules.'
-  Enabled: false
-
-# More comfortable block layouts
-Style/BlockDelimiters:
   Enabled: False
 
-Style/MultilineBlockLayout:
+Style/DefWithParentheses:
+  Enabled: True
+
+Style/PreferredHashMethods:
+  Enabled: True
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+Style/DoubleNegation:
+  Enabled: True
+
+Style/EachWithObject:
+  Enabled: True
+
+Style/EmptyLineBetweenDefs:
+  Enabled: True
+
+Style/IndentArray:
+  Enabled: True
+
+Style/IndentHash:
+  Enabled: True
+
+Style/IndentationConsistency:
+  Enabled: True
+
+Style/IndentationWidth:
+  Enabled: True
+
+Style/EmptyLines:
+  Enabled: True
+
+Style/EmptyLinesAroundAccessModifier:
+  Enabled: True
+
+Style/EmptyLiteral:
+  Enabled: True
+
+# Configuration parameters: AllowURI, URISchemes.
+Metrics/LineLength:
   Enabled: False
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: True
+
+Style/MethodDefParentheses:
+  Enabled: True
+
+Style/LineEndConcatenation:
+  Enabled: True
+
+Style/TrailingWhitespace:
+  Enabled: True
+
+Style/StringLiterals:
+  Enabled: True
+
+Style/TrailingCommaInArguments:
+  Enabled: True
+
+Style/TrailingCommaInLiteral:
+  Enabled: True
+
+Style/GlobalVars:
+  Enabled: True
+
+Style/GuardClause:
+  Enabled: True
+
+Style/IfUnlessModifier:
+  Enabled: True
+
+Style/MultilineIfThen:
+  Enabled: True
+
+Style/NegatedIf:
+  Enabled: True
+
+Style/NegatedWhile:
+  Enabled: True
+
+Style/Next:
+  Enabled: True
+
+Style/SingleLineBlockParams:
+  Enabled: True
+
+Style/SingleLineMethods:
+  Enabled: True
+
+Style/SpecialGlobalVars:
+  Enabled: True
+
+Style/TrivialAccessors:
+  Enabled: True
+
+Style/UnlessElse:
+  Enabled: True
+
+Style/VariableInterpolation:
+  Enabled: True
 
 Style/VariableName:
-  EnforcedStyle: snake_case
+  Enabled: True
+
+Style/WhileUntilDo:
+  Enabled: True
+
+Style/EvenOdd:
+  Enabled: True
+
+Style/FileName:
+  Enabled: True
+
+Style/For:
+  Enabled: True
+
+Style/Lambda:
+  Enabled: True
+
+Style/MethodName:
+  Enabled: True
+
+Style/MultilineTernaryOperator:
+  Enabled: True
+
+Style/NestedTernaryOperator:
+  Enabled: True
+
+Style/NilComparison:
+  Enabled: True
+
+Style/FormatString:
+  Enabled: True
+
+Style/MultilineBlockChain:
+  Enabled: True
+
+Style/Semicolon:
+  Enabled: True
+
+Style/SignalException:
+  Enabled: True
+
+Style/NonNilCheck:
+  Enabled: True
+
+Style/Not:
+  Enabled: True
+
+Style/NumericLiterals:
+  Enabled: True
+
+Style/OneLineConditional:
+  Enabled: True
+
+Style/OpMethod:
+  Enabled: True
+
+Style/ParenthesesAroundCondition:
+  Enabled: True
+
+Style/PercentLiteralDelimiters:
+  Enabled: True
+
+Style/PerlBackrefs:
+  Enabled: True
+
+Style/PredicateName:
+  Enabled: True
+
+Style/RedundantException:
+  Enabled: True
+
+Style/SelfAssignment:
+  Enabled: True
+
+Style/Proc:
+  Enabled: True
+
+Style/RaiseArgs:
+  Enabled: True
+
+Style/RedundantBegin:
+  Enabled: True
+
+Style/RescueModifier:
+  Enabled: True
+
+# based on https://github.com/voxpupuli/modulesync_config/issues/168
+Style/RegexpLiteral:
+  EnforcedStyle: percent_r
+  Enabled: True
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: True
+
+Metrics/ParameterLists:
+  Enabled: False
+
+Lint/RequireParentheses:
+  Enabled: True
+
+Style/SpaceBeforeFirstArg:
+  Enabled: True
+
+Style/ModuleFunction:
+  Enabled: True
+
+Lint/Debugger:
+  Enabled: True
+
+Style/IfWithSemicolon:
+  Enabled: True
+
+Style/Encoding:
+  Enabled: True
+
+Style/BlockDelimiters:
+  Enabled: True
+
+Style/MultilineBlockLayout:
+  Enabled: True
+
+# 'Complexity' is very relative
+Metrics/AbcSize:
+  Enabled: False
+
+# 'Complexity' is very relative
+Metrics/PerceivedComplexity:
+  Enabled: False
+
+Lint/UselessAssignment:
+  Enabled: True
+
+Style/ClosingParenthesisIndentation:
+  Enabled: True
+
+# RSpec
+
+# We don't use rspec in this way
+RSpec/DescribeClass:
+  Enabled: False
+
+# Example length is not necessarily an indicator of code quality
+RSpec/ExampleLength:
+  Enabled: False
+
+RSpec/NamedSubject:
+  Enabled: False
+
+# disabled for now since they cause a lot of issues
+# these issues aren't easy to fix
+RSpec/RepeatedDescription:
+  Enabled: False
+
+RSpec/NestedGroups:
+  Enabled: False
+
+# disable Yaml safe_load. This is needed to support ruby2.0.0 development envs
+Security/YAMLLoad:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.1
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ group :test do
   gem 'puppet-lint-classes_and_types_beginning_with_digits-check',  :require => false
   gem 'puppet-lint-unquoted_string-check',                          :require => false
   gem 'puppet-lint-variable_contains_upcase',                       :require => false
+  gem 'rubocop-rspec',                                              :require => false
+  gem 'rspec-puppet-facts',                                         :require => false
 end
 
 group :development do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,10 +40,10 @@
 #   by the nfs server.
 #
 # [*idmapd_file*]
-#   String. It defines the location of th file with the idmapd settings.
+#   String. It defines the location of the file with the idmapd settings.
 #
 # [*defaults_file*]
-#   String. It defines the location of th file with the nfs settings.
+#   String. It defines the location of the file with the nfs settings.
 #
 # [*manage_packages*]
 #   Boolean. It defines if the packages should be managed through this module
@@ -162,113 +162,50 @@
 #
 
 class nfs(
-  $ensure                       = 'present',
-  $server_enabled               = false,
-  $client_enabled               = false,
-  $nfs_v4                       = $::nfs::params::nfs_v4,
-  $nfs_v4_client                = $::nfs::params::nfs_v4,
-  $exports_file                 = $::nfs::params::exports_file,
-  $idmapd_file                  = $::nfs::params::idmapd_file,
-  $defaults_file                = $::nfs::params::defaults_file,
-  $manage_packages              = true,
-  $server_packages              = $::nfs::params::server_packages,
-  $server_package_ensure        = 'installed',
-  $client_packages              = $::nfs::params::client_packages,
-  $client_package_ensure        = 'installed',
-  $manage_server_service        = true,
-  $manage_server_servicehelper  = true,
-  $manage_client_service        = true,
-  $server_service_name          = $::nfs::params::server_service_name,
-  $server_service_ensure        = 'running',
-  $server_service_enable        = true,
-  $server_service_hasrestart    = $::nfs::params::server_service_hasrestart,
-  $server_service_hasstatus     = $::nfs::params::server_service_hasstatus,
-  $server_service_restart_cmd   = $::nfs::params::server_service_restart_cmd,
-  $server_nfsv4_servicehelper   = $::nfs::params::server_nfsv4_servicehelper,
-  $client_services              = $::nfs::params::client_services,
-  $client_nfsv4_services        = $::nfs::params::client_nfsv4_services,
-  $client_services_hasrestart   = $::nfs::params::client_services_hasrestart,
-  $client_services_hasstatus    = $::nfs::params::client_services_hasstatus,
-  $client_idmapd_setting        = $::nfs::params::client_idmapd_setting,
-  $client_nfs_fstype            = $::nfs::params::client_nfs_fstype,
-  $client_nfs_options           = $::nfs::params::client_nfs_options,
-  $client_nfsv4_fstype          = $::nfs::params::client_nfsv4_fstype,
-  $client_nfsv4_options         = $::nfs::params::client_nfsv4_options,
-  $nfs_v4_export_root           = $::nfs::params::nfs_v4_export_root,
-  $nfs_v4_export_root_clients   = $::nfs::params::nfs_v4_export_root_clients,
-  $nfs_v4_mount_root            = $::nfs::params::nfs_v4_mount_root,
-  $nfs_v4_idmap_domain          = $::nfs::params::nfs_v4_idmap_domain,
-  $nfs_v4_root_export_ensure    = 'mounted',
-  $nfs_v4_root_export_mount     = undef,
-  $nfs_v4_root_export_remounts  = false,
-  $nfs_v4_root_export_atboot    = false,
-  $nfs_v4_root_export_options   = '_netdev',
-  $nfs_v4_root_export_bindmount = undef,
-  $nfs_v4_root_export_tag       = undef,
+  Enum['present', 'absent', 'running', 'stopped', 'disabled'] $ensure                 = 'present',
+  Boolean $server_enabled                                                             = false,
+  Boolean $client_enabled                                                             = false,
+  Boolean $nfs_v4                                                                     = $::nfs::params::nfs_v4,
+  Boolean $nfs_v4_client                                                              = $::nfs::params::nfs_v4,
+  String $exports_file                                                                = $::nfs::params::exports_file,
+  String $idmapd_file                                                                 = $::nfs::params::idmapd_file,
+  Optional[String] $defaults_file                                                     = $::nfs::params::defaults_file,
+  Boolean $manage_packages                                                            = true,
+  Array $server_packages                                                              = $::nfs::params::server_packages,
+  String $server_package_ensure                                                       = 'installed',
+  Array $client_packages                                                              = $::nfs::params::client_packages,
+  String $client_package_ensure                                                       = 'installed',
+  Boolean $manage_server_service                                                      = true,
+  Boolean $manage_server_servicehelper                                                = true,
+  Boolean $manage_client_service                                                      = true,
+  String $server_service_name                                                         = $::nfs::params::server_service_name,
+  Enum['present', 'absent', 'running', 'stopped', 'disabled'] $server_service_ensure  = 'running',
+  Boolean $server_service_enable                                                      = true,
+  Boolean $server_service_hasrestart                                                  = $::nfs::params::server_service_hasrestart,
+  Boolean $server_service_hasstatus                                                   = $::nfs::params::server_service_hasstatus,
+  Optional[String] $server_service_restart_cmd                                        = $::nfs::params::server_service_restart_cmd,
+  Optional[String] $server_nfsv4_servicehelper                                        = $::nfs::params::server_nfsv4_servicehelper,
+  $client_services                                                                    = $::nfs::params::client_services,
+  $client_nfsv4_services                                                              = $::nfs::params::client_nfsv4_services,
+  Boolean $client_services_hasrestart                                                 = $::nfs::params::client_services_hasrestart,
+  Boolean $client_services_hasstatus                                                  = $::nfs::params::client_services_hasstatus,
+  Array[String] $client_idmapd_setting                                                = $::nfs::params::client_idmapd_setting,
+  String $client_nfs_fstype                                                           = $::nfs::params::client_nfs_fstype,
+  String $client_nfs_options                                                          = $::nfs::params::client_nfs_options,
+  String $client_nfsv4_fstype                                                         = $::nfs::params::client_nfsv4_fstype,
+  String $client_nfsv4_options                                                        = $::nfs::params::client_nfsv4_options,
+  String $nfs_v4_export_root                                                          = $::nfs::params::nfs_v4_export_root,
+  String $nfs_v4_export_root_clients                                                  = $::nfs::params::nfs_v4_export_root_clients,
+  String $nfs_v4_mount_root                                                           = $::nfs::params::nfs_v4_mount_root,
+  String $nfs_v4_idmap_domain                                                         = $::nfs::params::nfs_v4_idmap_domain,
+  String $nfs_v4_root_export_ensure                                                   = 'mounted',
+  Optional[String] $nfs_v4_root_export_mount                                          = undef,
+  Boolean $nfs_v4_root_export_remounts                                                = false,
+  Boolean $nfs_v4_root_export_atboot                                                  = false,
+  String $nfs_v4_root_export_options                                                  = '_netdev',
+  Optional[String] $nfs_v4_root_export_bindmount                                      = undef,
+  Optional[String] $nfs_v4_root_export_tag                                            = undef,
 ) inherits nfs::params {
-
-  # validate all params
-
-  if ! ($ensure in [ 'present', 'absent', 'running', 'stopped', 'disabled' ]) {
-    fail("\"${$ensure}\" is not a valid ensure parameter value")
-  }
-
-  validate_bool($server_enabled)
-  validate_bool($client_enabled)
-  validate_bool($nfs_v4)
-  validate_bool($nfs_v4_client)
-  validate_string($exports_file)
-  validate_string($idmapd_file)
-  validate_string($defaults_file)
-  validate_bool($manage_packages)
-  validate_array($server_packages)
-  validate_string($server_package_ensure)
-  validate_array($client_packages)
-  validate_string($client_package_ensure)
-  validate_bool($manage_server_service)
-  validate_bool($manage_server_servicehelper)
-  validate_bool($manage_client_service)
-  validate_string($server_service_name)
-
-  if ! ($server_service_ensure in [ 'present', 'absent', 'running', 'stopped', 'disabled' ]) {
-    fail("\"${server_service_ensure}\" is not a valid ensure parameter value")
-  }
-
-  validate_bool($server_service_enable)
-  validate_bool($server_service_hasrestart)
-  validate_bool($server_service_hasstatus)
-  validate_string($server_service_restart_cmd)
-  validate_string($server_nfsv4_servicehelper)
-  validate_hash($client_services)
-  validate_hash($client_nfsv4_services)
-  validate_bool($client_services_hasrestart)
-  validate_bool($client_services_hasstatus)
-  validate_array($client_idmapd_setting)
-  validate_string($client_nfs_fstype)
-  validate_string($client_nfs_options)
-  validate_string($client_nfsv4_fstype)
-  validate_string($client_nfsv4_options)
-  validate_string($nfs_v4_export_root)
-  validate_string($nfs_v4_export_root_clients)
-  validate_string($nfs_v4_mount_root)
-  validate_string($nfs_v4_idmap_domain)
-  validate_string($nfs_v4_root_export_ensure)
-
-  if $nfs_v4_root_export_mount != undef  {
-    validate_string($nfs_v4_root_export_mount)
-  }
-
-  validate_bool($nfs_v4_root_export_remounts)
-  validate_bool($nfs_v4_root_export_atboot)
-  validate_string($nfs_v4_root_export_options)
-
-  if $nfs_v4_root_export_bindmount != undef  {
-    validate_string($nfs_v4_root_export_bindmount)
-  }
-
-  if $nfs_v4_root_export_tag != undef  {
-    validate_string($nfs_v4_root_export_tag)
-  }
 
   if $server_enabled {
 

--- a/metadata.json
+++ b/metadata.json
@@ -69,12 +69,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0 < 5.0.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.6.1 < 5.0.0"
     }
   ]
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -18,7 +18,7 @@ describe 'nfs class' do
   describe 'include nfs without params' do
     context 'default parameters' do
       let(:pp) { "class { 'nfs': }" }
-      it 'should apply without errors without params' do
+      it 'applies without errors without params' do
         apply_manifest('include nfs', catch_failures: true)
       end
     end
@@ -48,11 +48,11 @@ describe 'nfs class' do
         }
       EOS
 
-      it 'should work with no errors based on the example' do
-        expect(apply_manifest(server_pp).exit_code).to_not eq(1)
+      it 'works with no errors based on the example' do
+        expect(apply_manifest(server_pp).exit_code).not_to eq(1)
       end
 
-      it 'should run a second time without changes' do
+      it 'runs a second time without changes' do
         expect(apply_manifest(server_pp).exit_code).to eq(0)
       end
 

--- a/spec/classes/nfs_spec.rb
+++ b/spec/classes/nfs_spec.rb
@@ -4,13 +4,14 @@ describe 'nfs' do
   supported_os = %w(Ubuntu_default Ubuntu_16.04 Debian_default Debian_8 RedHat_default RedHat_7 Gentoo SLES Archlinux)
   supported_os.each do |os|
     context os do
-      let(:default_facts) do {
-        concat_basedir: '/tmp',
-        clientcert: 'test.host',
-        is_pe: false,
-        id: 'root',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      }
+      let(:default_facts) do
+        {
+          concat_basedir: '/tmp',
+          clientcert: 'test.host',
+          is_pe: false,
+          id: 'root',
+          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+        }
       end
 
       ### vv switch case to set OS specific values vv ###
@@ -23,7 +24,7 @@ describe 'nfs' do
             operatingsystem: 'Ubuntu',
             osfamily: 'Debian',
             operatingsystemmajrelease: '14.04',
-            lsbdistcodename: 'trusty',
+            lsbdistcodename: 'trusty'
           )
         end
         server_service = 'nfs-kernel-server'
@@ -40,7 +41,7 @@ describe 'nfs' do
             operatingsystem: 'Ubuntu',
             osfamily: 'Debian',
             operatingsystemmajrelease: '16.04',
-            lsbdistcodename: 'xenial',
+            lsbdistcodename: 'xenial'
           )
         end
         server_service = 'nfs-server'
@@ -57,7 +58,7 @@ describe 'nfs' do
             operatingsystem: 'Debian',
             osfamily: 'Debian',
             operatingsystemmajrelease: '7',
-            lsbdistcodename: 'wheezy',
+            lsbdistcodename: 'wheezy'
           )
         end
         server_service = 'nfs-kernel-server'
@@ -74,7 +75,7 @@ describe 'nfs' do
             operatingsystem: 'Debian',
             osfamily: 'Debian',
             operatingsystemmajrelease: '8',
-            lsbdistcodename: 'jessie',
+            lsbdistcodename: 'jessie'
           )
         end
         server_service = 'nfs-kernel-server'
@@ -90,7 +91,7 @@ describe 'nfs' do
           default_facts.merge(
             operatingsystem: 'RedHat',
             osfamily: 'RedHat',
-            operatingsystemmajrelease: '8',
+            operatingsystemmajrelease: '8'
           )
         end
         server_service = 'nfs'
@@ -106,7 +107,7 @@ describe 'nfs' do
           default_facts.merge(
             operatingsystem: 'RedHat',
             osfamily: 'RedHat',
-            operatingsystemmajrelease: '7',
+            operatingsystemmajrelease: '7'
           )
         end
         server_service = 'nfs-server.service'
@@ -122,7 +123,7 @@ describe 'nfs' do
           default_facts.merge(
             operatingsystem: 'Gentoo',
             osfamily: 'Gentoo',
-            operatingsystemmajrelease: '1',
+            operatingsystemmajrelease: '1'
           )
         end
         server_service = 'nfs'
@@ -138,7 +139,7 @@ describe 'nfs' do
           default_facts.merge(
             operatingsystem: 'SLES',
             osfamily: 'Suse',
-            operatingsystemmajrelease: '12',
+            operatingsystemmajrelease: '12'
           )
         end
         server_service = 'nfsserver'
@@ -154,7 +155,7 @@ describe 'nfs' do
           default_facts.merge(
             operatingsystem: 'Archlinux',
             osfamily: 'Archlinux',
-            operatingsystemmajrelease: '3',
+            operatingsystemmajrelease: '3'
           )
         end
         server_service = 'nfs-server.service'
@@ -170,64 +171,67 @@ describe 'nfs' do
       it { is_expected.to compile.with_all_deps }
 
       context 'server_enabled => true, client_enabled => false' do
-        let(:params) { { server_enabled: true, client_enabled: false, } }
-        it { should contain_class('nfs::server::config') }
-        it { should contain_class('nfs::server::package') }
-        it { should contain_class('nfs::server::service') }
-        it { should contain_concat__fragment('nfs_exports_header').with('target' => '/etc/exports') }
+        let(:params) { { server_enabled: true, client_enabled: false } }
+        it { is_expected.to contain_class('nfs::server::config') }
+        it { is_expected.to contain_class('nfs::server::package') }
+        it { is_expected.to contain_class('nfs::server::service') }
+        it { is_expected.to contain_concat__fragment('nfs_exports_header').with('target' => '/etc/exports') }
 
         server_packages.each do |package|
           context os do
-            it { should contain_package(package) }
+            it { is_expected.to contain_package(package) }
           end
         end
 
         context 'nfs_v4 => true' do
           let(:params) { { nfs_v4: true, server_enabled: true, client_enabled: false, nfs_v4_idmap_domain: 'teststring' } }
-          it { should contain_concat__fragment('nfs_exports_root').with('target' => '/etc/exports') }
-          it { should contain_file('/export').with('ensure' => 'directory') }
-          it { should contain_augeas('/etc/idmapd.conf').with_changes(/set Domain teststring/) }
+          it { is_expected.to contain_concat__fragment('nfs_exports_root').with('target' => '/etc/exports') }
+          it { is_expected.to contain_file('/export').with('ensure' => 'directory') }
+          it { is_expected.to contain_augeas('/etc/idmapd.conf').with_changes(%r{set Domain teststring}) }
           context os do
             if server_servicehelper != ''
-              it { should contain_service(server_servicehelper)
-                .with('ensure' => 'running')
-                .with_subscribe(['Concat[/etc/exports]', 'Augeas[/etc/idmapd.conf]'])
-              }
+              it do
+                is_expected.to contain_service(server_servicehelper).
+                  with('ensure' => 'running').
+                  with_subscribe(['Concat[/etc/exports]', 'Augeas[/etc/idmapd.conf]'])
+              end
             end
           end
         end
       end
 
       context 'server_enabled => false, client_enabled => true' do
-        let(:params) { { server_enabled: false, client_enabled: true, } }
-        it { should contain_class('nfs::client::config') }
-        it { should contain_class('nfs::client::package') }
-        it { should contain_class('nfs::client::service') }
+        let(:params) { { server_enabled: false, client_enabled: true } }
+        it { is_expected.to contain_class('nfs::client::config') }
+        it { is_expected.to contain_class('nfs::client::package') }
+        it { is_expected.to contain_class('nfs::client::service') }
         context os do
           client_services.each do |service|
-            it { should contain_service(service)
-              .with('ensure' => 'running')
-              .with_subscribe([])
-            }
+            it do
+              is_expected.to contain_service(service).
+                with('ensure' => 'running').
+                with_subscribe([])
+            end
           end
         end
 
         context 'nfs_v4 => true' do
-          let(:params) { { nfs_v4_client: true, server_enabled: false, client_enabled: true, } }
-          it { should contain_augeas('/etc/idmapd.conf') }
+          let(:params) { { nfs_v4_client: true, server_enabled: false, client_enabled: true } }
+          it { is_expected.to contain_augeas('/etc/idmapd.conf') }
           client_nfs_vfour_services.each do |service|
             context os do
-              it { should contain_service(service)
-                .with('ensure' => 'running')
-                .with_subscribe(/Augeas/)
-              }
+              it do
+                is_expected.to contain_service(service).
+                  with('ensure' => 'running').
+                  with_subscribe(%r{Augeas})
+              end
             end
           end
           client_packages.each do |package|
             context os do
               client_nfs_vfour_services.each do |service|
                 service = 'Service[' + service + ']'
-                it { should contain_package(package).that_notifies(service) }
+                it { is_expected.to contain_package(package).that_notifies(service) }
               end
             end
           end
@@ -235,64 +239,65 @@ describe 'nfs' do
       end
 
       context 'server_enabled => true, client_enabled => true' do
-        let(:params) { { server_enabled: true, client_enabled: true, } }
-        it { should contain_class('nfs::server::config') }
-        it { should contain_class('nfs::server::package') }
-        it { should contain_class('nfs::server::service') }
-        it { should contain_class('nfs::client::config') }
-        it { should contain_class('nfs::client::package') }
-        it { should contain_class('nfs::client::service') }
-        it { should contain_concat__fragment('nfs_exports_header').with('target' => '/etc/exports') }
+        let(:params) { { server_enabled: true, client_enabled: true } }
+        it { is_expected.to contain_class('nfs::server::config') }
+        it { is_expected.to contain_class('nfs::server::package') }
+        it { is_expected.to contain_class('nfs::server::service') }
+        it { is_expected.to contain_class('nfs::client::config') }
+        it { is_expected.to contain_class('nfs::client::package') }
+        it { is_expected.to contain_class('nfs::client::service') }
+        it { is_expected.to contain_concat__fragment('nfs_exports_header').with('target' => '/etc/exports') }
 
         context 'nfs_v4 => true, nfs_v4_client => true' do
           let(:params) { { nfs_v4: true, nfs_v4_client: true, server_enabled: true, client_enabled: true, nfs_v4_idmap_domain: 'teststring' } }
-          it { should contain_augeas('/etc/idmapd.conf') }
-          it { should contain_concat__fragment('nfs_exports_root').with('target' => '/etc/exports') }
-          it { should contain_file('/export').with('ensure' => 'directory') }
-          it { should contain_augeas('/etc/idmapd.conf').with_changes(/set Domain teststring/) }
+          it { is_expected.to contain_augeas('/etc/idmapd.conf') }
+          it { is_expected.to contain_concat__fragment('nfs_exports_root').with('target' => '/etc/exports') }
+          it { is_expected.to contain_file('/export').with('ensure' => 'directory') }
+          it { is_expected.to contain_augeas('/etc/idmapd.conf').with_changes(%r{set Domain teststring}) }
           context os do
             if server_servicehelper != ''
-              it { should contain_service(server_servicehelper)
-                .with('ensure' => 'running')
-                .with_subscribe(['Concat[/etc/exports]', 'Augeas[/etc/idmapd.conf]'])
-              }
+              it do
+                is_expected.to contain_service(server_servicehelper).
+                  with('ensure' => 'running').
+                  with_subscribe(['Concat[/etc/exports]', 'Augeas[/etc/idmapd.conf]'])
+              end
             end
           end
           server_packages.each do |package|
             context os do
               service = 'Service[' + server_service + ']'
-              it { should contain_package(package).that_notifies(service) }
+              it { is_expected.to contain_package(package).that_notifies(service) }
             end
           end
         end
       end
 
       context ':nfs_v4_client => true, :nfs_v4 => true, :server_enabled => true, :client_enabled => true, :manage_packages => false' do
-        let(:params) { { nfs_v4_client: true, nfs_v4: true, client_enabled: true, server_enabled: true, manage_packages: false, } }
+        let(:params) { { nfs_v4_client: true, nfs_v4: true, client_enabled: true, server_enabled: true, manage_packages: false } }
         client_packages.each do |package|
           context os do
-            it { should_not contain_package(package) }
+            it { is_expected.not_to contain_package(package) }
           end
         end
         server_packages.each do |package|
           context os do
-            it { should_not contain_package(package) }
+            it { is_expected.not_to contain_package(package) }
           end
         end
       end
 
       context ':nfs_v4_client => true, :nfs_v4 => true, :server_enabled => true, :manage_server_service => false, manage_server_servicehelper => false, :manage_client_service => false' do
-        let(:params) { { nfs_v4_client: true, nfs_v4: true, client_enabled: true, server_enabled: true, manage_server_service: false, manage_server_servicehelper: false, manage_client_service: false, } }
+        let(:params) { { nfs_v4_client: true, nfs_v4: true, client_enabled: true, server_enabled: true, manage_server_service: false, manage_server_servicehelper: false, manage_client_service: false } }
         client_nfs_vfour_services.each do |service|
           context os do
-            it { should_not contain_service(service) }
+            it { is_expected.not_to contain_service(service) }
           end
         end
         context os do
-          it { should_not contain_service(server_service) }
+          it { is_expected.not_to contain_service(server_service) }
         end
         context os do
-          it { should_not contain_service(server_servicehelper) }
+          it { is_expected.not_to contain_service(server_servicehelper) }
         end
       end
     end

--- a/spec/defines/client_mount_spec.rb
+++ b/spec/defines/client_mount_spec.rb
@@ -2,107 +2,117 @@ require 'spec_helper'
 
 describe 'nfs::client::mount', type: 'define' do
   context 'nfs_v4 => false, minimal arguments' do
-    let(:facts) { {
-      operatingsystem: 'Ubuntu',
-      osfamily: 'Debian',
-      operatingsystemmajrelease: '12.04',
-      lsbdistcodename: 'precise',
-      concat_basedir: '/dne',
-      clientcert: 'example.com',
-      is_pe: false,
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    } }
+    let(:facts) do
+      {
+        operatingsystem: 'Ubuntu',
+        osfamily: 'Debian',
+        operatingsystemmajrelease: '12.04',
+        lsbdistcodename: 'precise',
+        concat_basedir: '/dne',
+        clientcert: 'example.com',
+        is_pe: false,
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      }
+    end
     let(:title) { '/srv/test' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true,}' }
 
     let(:params) { { server: '1.2.3.4' } }
-    it { should contain_nfs__functions__mkdir('/srv/test') }
-    it { should contain_mount('shared /srv/test by 1.2.3.4 on /srv/test') }
+    it { is_expected.to contain_nfs__functions__mkdir('/srv/test') }
+    it { is_expected.to contain_mount('shared /srv/test by 1.2.3.4 on /srv/test') }
   end
 
   context 'nfs_v4 => false, specified mountpoint and sharename' do
-    let(:facts) { {
-      operatingsystem: 'Ubuntu',
-      osfamily: 'Debian',
-      operatingsystemmajrelease: '12.04',
-      lsbdistcodename: 'precise',
-      concat_basedir: '/dne',
-      clientcert: 'example.com',
-      is_pe: false,
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    } }
+    let(:facts) do
+      {
+        operatingsystem: 'Ubuntu',
+        osfamily: 'Debian',
+        operatingsystemmajrelease: '12.04',
+        lsbdistcodename: 'precise',
+        concat_basedir: '/dne',
+        clientcert: 'example.com',
+        is_pe: false,
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      }
+    end
     let(:title) { 'Import /srv' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true,}' }
 
     let(:params) { { share: '/export/srv', mount: '/srv', server: '1.2.3.4' } }
-    it { should contain_nfs__functions__mkdir('/srv') }
-    it { should contain_mount('shared /export/srv by 1.2.3.4 on /srv') }
+    it { is_expected.to contain_nfs__functions__mkdir('/srv') }
+    it { is_expected.to contain_mount('shared /export/srv by 1.2.3.4 on /srv') }
   end
 
   context 'nfs_v4 => true, specified share' do
-    let(:facts) { {
-      operatingsystem: 'Ubuntu',
-      osfamily: 'Debian',
-      operatingsystemmajrelease: '12.04',
-      lsbdistcodename: 'precise',
-      concat_basedir: '/dne',
-      clientcert: 'example.com',
-      is_pe: false,
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    } }
+    let(:facts) do
+      {
+        operatingsystem: 'Ubuntu',
+        osfamily: 'Debian',
+        operatingsystemmajrelease: '12.04',
+        lsbdistcodename: 'precise',
+        concat_basedir: '/dne',
+        clientcert: 'example.com',
+        is_pe: false,
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      }
+    end
     let(:title) { '/srv/test' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true, nfs_v4_client => true }' }
 
     let(:params) { { share: 'test', server: '1.2.3.4' } }
-    it { should contain_nfs__functions__mkdir('/srv/test') }
-    it { should contain_mount('shared /test by 1.2.3.4 on /srv/test') }
+    it { is_expected.to contain_nfs__functions__mkdir('/srv/test') }
+    it { is_expected.to contain_mount('shared /test by 1.2.3.4 on /srv/test') }
   end
 
   context 'nfs_v4 => true, minimal arguments' do
-    let(:facts) { {
-      operatingsystem: 'Ubuntu',
-      osfamily: 'Debian',
-      operatingsystemmajrelease: '12.04',
-      lsbdistcodename: 'precise',
-      concat_basedir: '/dne',
-      clientcert: 'example.com',
-      is_pe: false,
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    } }
+    let(:facts) do
+      {
+        operatingsystem: 'Ubuntu',
+        osfamily: 'Debian',
+        operatingsystemmajrelease: '12.04',
+        lsbdistcodename: 'precise',
+        concat_basedir: '/dne',
+        clientcert: 'example.com',
+        is_pe: false,
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      }
+    end
     let(:title) { '/srv/test' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true, nfs_v4_client => true }' }
 
     let(:params) { { server: '1.2.3.4' } }
-    it { should contain_nfs__functions__mkdir('/srv/test') }
-    it { should contain_mount('shared /test by 1.2.3.4 on /srv/test') }
+    it { is_expected.to contain_nfs__functions__mkdir('/srv/test') }
+    it { is_expected.to contain_mount('shared /test by 1.2.3.4 on /srv/test') }
   end
 
   context 'nfs_v4 => true, non-default mountpoints' do
-    let(:facts) { {
-      operatingsystem: 'Ubuntu',
-      osfamily: 'Debian',
-      operatingsystemmajrelease: '12.04',
-      lsbdistcodename: 'precise',
-      concat_basedir: '/dne',
-      clientcert: 'example.com',
-      is_pe: false,
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    } }
+    let(:facts) do
+      {
+        operatingsystem: 'Ubuntu',
+        osfamily: 'Debian',
+        operatingsystemmajrelease: '12.04',
+        lsbdistcodename: 'precise',
+        concat_basedir: '/dne',
+        clientcert: 'example.com',
+        is_pe: false,
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      }
+    end
     let(:title) { '/opt/sample' }
 
     let(:pre_condition) { 'class {"nfs": client_enabled => true, nfs_v4_client => true }' }
 
     let(:params) { { share: 'test', server: '1.2.3.4' } }
-    it { should contain_nfs__functions__mkdir('/opt/sample') }
-    it { should contain_mount('shared /test by 1.2.3.4 on /opt/sample') }
+    it { is_expected.to contain_nfs__functions__mkdir('/opt/sample') }
+    it { is_expected.to contain_mount('shared /test by 1.2.3.4 on /opt/sample') }
   end
 end

--- a/spec/defines/server_export_spec.rb
+++ b/spec/defines/server_export_spec.rb
@@ -2,45 +2,49 @@ require 'spec_helper'
 
 describe 'nfs::server::export', type: 'define' do
   context 'nvs_v4 => false' do
-    let(:facts) { {
-      operatingsystem: 'Ubuntu',
-      osfamily: 'Debian',
-      operatingsystemmajrelease: '12.04',
-      lsbdistcodename: 'precise',
-      concat_basedir: '/dne',
-      is_pe: false,
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    } }
+    let(:facts) do
+      {
+        operatingsystem: 'Ubuntu',
+        osfamily: 'Debian',
+        operatingsystemmajrelease: '12.04',
+        lsbdistcodename: 'precise',
+        concat_basedir: '/dne',
+        is_pe: false,
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      }
+    end
     let(:title) { '/srv/test' }
 
     let(:pre_condition) { 'class {"nfs": server_enabled => true,}' }
 
     let(:params) { { clients: '1.2.3.4(rw)' } }
     it do
-      should contain_nfs__functions__create_export('/srv/test').with('ensure' => 'mounted', 'clients' => '1.2.3.4(rw)')
+      is_expected.to contain_nfs__functions__create_export('/srv/test').with('ensure' => 'mounted', 'clients' => '1.2.3.4(rw)')
     end
   end
   context 'nvs_v4 => true' do
-    let(:facts) { {
-      operatingsystem: 'Ubuntu',
-      osfamily: 'Debian',
-      operatingsystemmajrelease: '12.04',
-      lsbdistcodename: 'precise',
-      concat_basedir: '/dne',
-      is_pe: false,
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    } }
+    let(:facts) do
+      {
+        operatingsystem: 'Ubuntu',
+        osfamily: 'Debian',
+        operatingsystemmajrelease: '12.04',
+        lsbdistcodename: 'precise',
+        concat_basedir: '/dne',
+        is_pe: false,
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      }
+    end
     let(:title) { '/srv/test' }
     let(:pre_condition) { 'class {"nfs": server_enabled => true, nfs_v4 => true}' }
 
     let(:params) { { clients: '1.2.3.4(rw)', bind: 'sbind' } }
     it do
-      should contain_nfs__functions__nfsv4_bindmount('/srv/test').with('ensure' => 'mounted', 'v4_export_name' => 'test', 'bind' => 'sbind')
+      is_expected.to contain_nfs__functions__nfsv4_bindmount('/srv/test').with('ensure' => 'mounted', 'v4_export_name' => 'test', 'bind' => 'sbind')
     end
     it do
-      should contain_nfs__functions__create_export('/export/test').with('ensure' => 'mounted', 'clients' => '1.2.3.4(rw)')
+      is_expected.to contain_nfs__functions__create_export('/export/test').with('ensure' => 'mounted', 'clients' => '1.2.3.4(rw)')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,11 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 RSpec.configure do |c|
-  c.before :each do
-    # Ensure that we don't accidentally cache facts and environment
-    # between test cases.
-    Facter::Util::Loader.any_instance.stubs(:load_all)
-    Facter.clear
-    Facter.clear_messages
-
-    # Store any environment variables away to be restored later
-    @old_env = {}
-    ENV.each_key { |k| @old_env[k] = ENV[k] }
-  end
+  default_facts = {
+    puppetversion: Puppet.version,
+    facterversion: Facter.version
+  }
+  c.default_facts = default_facts
 end


### PR DESCRIPTION
This gets rid of all the legacy validate_* function calls and replaces them with proper data types.