### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,7 +209,7 @@ class nfs(
   Boolean $nfs_v4_root_export_atboot                                                  = false,
   String $nfs_v4_root_export_options                                                  = '_netdev',
   Optional[String] $nfs_v4_root_export_bindmount                                      = undef,
-  Optional[String] $nfs_v4_root_export_tag                                            = undef,
+  Optional[String] $nfs_v4_root_export_tag                                            = undef
 ) inherits nfs::params {
 
   if $server_enabled {


### PR DESCRIPTION
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Syntax error at 'Enum'; expected ')' at /etc/puppet/environments/colt_dev/modules/nfs/manifests/init.pp:169 on node AD-CLTWEB-01
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
