### PR TITLE
On Debian Jessie, the nfsv4 client uses nfs-common as a wrapper for r…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,7 +103,7 @@ class nfs::params {
           $client_services            = {'rpcbind' => {}}
           $client_nfsv4_fstype        = 'nfs4'
           $client_nfsv4_options       = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
-          $client_nfsv4_services      = {'rpcbind' => {}, 'idmapd' => {}}
+          $client_nfsv4_services      = {'rpcbind' => {}, 'nfs-common' => {}}
           $server_nfsv4_servicehelper = 'nfs-common'
           $server_service_name        = 'nfs-kernel-server'
         }

--- a/spec/classes/nfs_spec.rb
+++ b/spec/classes/nfs_spec.rb
@@ -82,7 +82,7 @@ describe 'nfs' do
         server_servicehelper = 'nfs-common'
         server_packages = %w(nfs-common nfs-kernel-server nfs4-acl-tools rpcbind)
         client_services = %w(rpcbind)
-        client_nfs_vfour_services = %w(rpcbind idmapd)
+        client_nfs_vfour_services = %w(rpcbind nfs-common)
         client_packages = %w(nfs-common nfs4-acl-tools)
 
       when 'RedHat_default'


### PR DESCRIPTION
…pc services (e.g. idmapd) to start

See https://github.com/derdanne/puppet-nfs/issues/57