### PR TITLE
RHEL 7.5 fixes the issue that this works around.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,26 +151,36 @@ class nfs::params {
           $client_idmapd_setting      = ['']
           $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
           $client_services_enable     = true
-          $client_services            = { 'rpcbind.service' => {
-                                            ensure => 'running',
-                                            enable => false,
-                                          },
-                                          'rpcbind.socket' => {
-                                            ensure => 'running',
-                                            enable => true,
-                                          },
-                                        }
+          if versioncmp($::operatingsystemrelease, '7.5') < 0 {
+            $client_services            = { 'rpcbind.service' => {
+                                              ensure => 'running',
+                                              enable => false,
+                                            },
+                                            'rpcbind.socket' => {
+                                              ensure => 'running',
+                                              enable => true,
+                                            },
+                                          }
+          }
+          else {
+            $client_services            = {'rpcbind.service' => {}}
+          }
           $client_nfsv4_fstype        = 'nfs4'
           $client_nfsv4_options       = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
-          $client_nfsv4_services      = { 'rpcbind.service' => {
-                                            ensure => 'running',
-                                            enable => false,
-                                          },
-                                          'rpcbind.socket' => {
-                                            ensure => 'running',
-                                            enable => true,
-                                          },
-                                        }
+          if versioncmp($::operatingsystemrelease, '7.5') < 0 {
+            $client_nfsv4_services      = { 'rpcbind.service' => {
+                                              ensure => 'running',
+                                              enable => false,
+                                            },
+                                            'rpcbind.socket' => {
+                                              ensure => 'running',
+                                              enable => true,
+                                            },
+                                          }
+          }
+          else {
+            $client_nfsv4_services      = {'rpcbind' => {}, 'rpcidmapd' => {}}
+          }
           $server_nfsv4_servicehelper = [ 'nfs-idmap.service' ]
           $server_service_name        = 'nfs-server.service'
         }

--- a/spec/classes/nfs_spec.rb
+++ b/spec/classes/nfs_spec.rb
@@ -132,7 +132,8 @@ describe 'nfs' do
           default_facts.merge(
             operatingsystem: 'RedHat',
             osfamily: 'RedHat',
-            operatingsystemmajrelease: '7'
+            operatingsystemmajrelease: '7',
+            operatingsystemrelease: '7.5'
           )
         end
 

--- a/spec/classes/nfs_spec.rb
+++ b/spec/classes/nfs_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'nfs' do
-  supported_os = %w[Ubuntu_default Ubuntu_16.04 Debian_default Debian_8 RedHat_default RedHat_7 Gentoo SLES Archlinux]
+  supported_os = %w[Ubuntu_default Ubuntu_16.04 Debian_default Debian_8 RedHat_default RedHat_7 RedHat_75 Gentoo SLES Archlinux]
   supported_os.each do |os|
     context os do
       let(:default_facts) do
@@ -133,7 +133,7 @@ describe 'nfs' do
             operatingsystem: 'RedHat',
             osfamily: 'RedHat',
             operatingsystemmajrelease: '7',
-            operatingsystemrelease: '7.5'
+            operatingsystemrelease: '7.4'
           )
         end
 
@@ -142,6 +142,24 @@ describe 'nfs' do
         server_packages = %w[nfs-utils nfs4-acl-tools rpcbind]
         client_services = %w[rpcbind.service rpcbind.socket]
         client_nfs_vfour_services = %w[rpcbind.service rpcbind.socket]
+        client_packages = %w[nfs-utils nfs4-acl-tools rpcbind]
+
+      when 'RedHat_75'
+
+        let(:facts) do
+          default_facts.merge(
+            operatingsystem: 'RedHat',
+            osfamily: 'RedHat',
+            operatingsystemmajrelease: '7',
+            operatingsystemrelease: '7.5'
+          )
+        end
+
+        server_service = 'nfs-server.service'
+        server_servicehelpers = %w[nfs-idmap.service]
+        server_packages = %w[nfs-utils nfs4-acl-tools rpcbind]
+        client_services = %w[rpcbind.service]
+        client_nfs_vfour_services = %w[rpcbind rpcidmapd]
         client_packages = %w[nfs-utils nfs4-acl-tools rpcbind]
 
       when 'Gentoo'


### PR DESCRIPTION
In RHEL 7.5, the strange params workaround causes a separate issue.  I believe it's because they actually fixed the bizarre behavior that was causing you to need the workaround in the first place.  The "new" issue only occurs on a first puppet run, and seems fine after.  Unfortunately I don't have a copy of the error in front of me but -- reverting back to 2.0.4 fixed the issue .. but then it caused issues for Ubuntu 16.

So anyway, this adds a simple check for "if we are running 7.5, then do it the old way that used to work".

Now with all that said, there is one caveat I want to make clear and possibly discuss before this is considered for merge.  Basically, this change causes rpcidmapd to be started:
/Stage[main]/Nfs::Client::Service/Service[rpcidmapd]/ensure | ensure changed 'stopped' to 'running'

So if there are tweaks you'd like me to make, maybe removing that part, please let me know and I'll be happy to.
