### PR TITLE
Don't enable rpcidmapd after all client-side.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,26 +151,36 @@ class nfs::params {
           $client_idmapd_setting      = ['']
           $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
           $client_services_enable     = true
-          $client_services            = { 'rpcbind.service' => {
-                                            ensure => 'running',
-                                            enable => false,
-                                          },
-                                          'rpcbind.socket' => {
-                                            ensure => 'running',
-                                            enable => true,
-                                          },
-                                        }
+          if versioncmp($::operatingsystemrelease, '7.5') < 0 {
+            $client_services            = { 'rpcbind.service' => {
+                                              ensure => 'running',
+                                              enable => false,
+                                            },
+                                            'rpcbind.socket' => {
+                                              ensure => 'running',
+                                              enable => true,
+                                            },
+                                          }
+          }
+          else {
+            $client_services            = {'rpcbind.service' => {}}
+          }
           $client_nfsv4_fstype        = 'nfs4'
           $client_nfsv4_options       = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
-          $client_nfsv4_services      = { 'rpcbind.service' => {
-                                            ensure => 'running',
-                                            enable => false,
-                                          },
-                                          'rpcbind.socket' => {
-                                            ensure => 'running',
-                                            enable => true,
-                                          },
-                                        }
+          if versioncmp($::operatingsystemrelease, '7.5') < 0 {
+            $client_nfsv4_services      = { 'rpcbind.service' => {
+                                              ensure => 'running',
+                                              enable => false,
+                                            },
+                                            'rpcbind.socket' => {
+                                              ensure => 'running',
+                                              enable => true,
+                                            },
+                                          }
+          }
+          else {
+            $client_nfsv4_services      = {'rpcbind' => {}, 'rpcidmapd' => {}}
+          }
           $server_nfsv4_servicehelper = [ 'nfs-idmap.service' ]
           $server_service_name        = 'nfs-server.service'
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -179,7 +179,7 @@ class nfs::params {
                                           }
           }
           else {
-            $client_nfsv4_services      = {'rpcbind' => {}, 'rpcidmapd' => {}}
+            $client_nfsv4_services      = {'rpcbind' => {}}
           }
           $server_nfsv4_servicehelper = [ 'nfs-idmap.service' ]
           $server_service_name        = 'nfs-server.service'

--- a/spec/classes/nfs_spec.rb
+++ b/spec/classes/nfs_spec.rb
@@ -132,7 +132,8 @@ describe 'nfs' do
           default_facts.merge(
             operatingsystem: 'RedHat',
             osfamily: 'RedHat',
-            operatingsystemmajrelease: '7'
+            operatingsystemmajrelease: '7',
+            operatingsystemrelease: '7.5'
           )
         end
 

--- a/spec/classes/nfs_spec.rb
+++ b/spec/classes/nfs_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'nfs' do
-  supported_os = %w[Ubuntu_default Ubuntu_16.04 Debian_default Debian_8 RedHat_default RedHat_7 Gentoo SLES Archlinux]
+  supported_os = %w[Ubuntu_default Ubuntu_16.04 Debian_default Debian_8 RedHat_default RedHat_7 RedHat_75 Gentoo SLES Archlinux]
   supported_os.each do |os|
     context os do
       let(:default_facts) do
@@ -133,7 +133,7 @@ describe 'nfs' do
             operatingsystem: 'RedHat',
             osfamily: 'RedHat',
             operatingsystemmajrelease: '7',
-            operatingsystemrelease: '7.5'
+            operatingsystemrelease: '7.4'
           )
         end
 
@@ -142,6 +142,24 @@ describe 'nfs' do
         server_packages = %w[nfs-utils nfs4-acl-tools rpcbind]
         client_services = %w[rpcbind.service rpcbind.socket]
         client_nfs_vfour_services = %w[rpcbind.service rpcbind.socket]
+        client_packages = %w[nfs-utils nfs4-acl-tools rpcbind]
+
+      when 'RedHat_75'
+
+        let(:facts) do
+          default_facts.merge(
+            operatingsystem: 'RedHat',
+            osfamily: 'RedHat',
+            operatingsystemmajrelease: '7',
+            operatingsystemrelease: '7.5'
+          )
+        end
+
+        server_service = 'nfs-server.service'
+        server_servicehelpers = %w[nfs-idmap.service]
+        server_packages = %w[nfs-utils nfs4-acl-tools rpcbind]
+        client_services = %w[rpcbind.service]
+        client_nfs_vfour_services = %w[rpcbind rpcidmapd]
         client_packages = %w[nfs-utils nfs4-acl-tools rpcbind]
 
       when 'Gentoo'


### PR DESCRIPTION
Howdy!  This is effectively a followup to my previous PR.  So, after doing some more testing and making this live for my entire environment, I found that it appears we are not supposed to be trying to start rpcidmapd on the clients side, under RHEL7, after all.  Now, I highly recommend someone else beyond me test this but let me lay down a few points I gathered from my research:

1. Well first off, it occurred to me that while I reverted back to 2.0.4, 2.0.5+ was not actually starting rpcidmapd, so I effectively reverted (added rpcidmapd) to the mix with my previous PR

2. I was finding that on some hosts (why it wasn't all of them I do not know), rpcidmapd was being started over and over -- left in an "unknown" state after reboot that it could never get out of (interestingly, restarting the service 'fixed' that, but it reverted again after another reboot)  So I did some looking around and found this solution from RedHat: https://access.redhat.com/solutions/209553 that indicates that you should not need to run rpcidmapd aka nfs-idmapd (rpcidmapd is symlinked to nfs-idmapd):
root@XXXXX:/usr/lib/systemd/system $ ls -l *idmapd*
-rw-r--r-- 1 root root 330 Feb 22 10:04 nfs-idmapd.service
lrwxrwxrwx 1 root root  18 Apr 10 03:58 rpcidmapd.service -> nfs-idmapd.service

I don't know if you have access to the RedHat solutions stuff so the gist of it is this:

> nfs-idmap.service should no longer be necessary in RHEL7's client side. And the keyring-based id mapping (using /usr/sbin/nfsidmap, as defined in /etc/request-key.d/id_resolver.conf) is a replacement the rpc.idmapd daemon.

This patch should revert the attempt to start that service, which has cleaned up the issue on my end.  It probably would be good if "more than I" could give it a test though.