### PR TITLE
This fixes a Duplicate declaration error

### DIFF
--- a/manifests/functions/create_export.pp
+++ b/manifests/functions/create_export.pp
@@ -49,7 +49,7 @@ define nfs::functions::create_export (
       content => $line,
     }
 
-    if ! defined(File[$name]) {
+    unless File["${name}"] {
       file { $name:
         ensure => directory,
         owner  => $owner,


### PR DESCRIPTION
On new versions of puppet the (! defined) does not seem to work any more. This is the preferred syntax.