### PR TITLE
this is a bind mount so don't change the SELinux Context

### DIFF
--- a/manifests/functions/create_export.pp
+++ b/manifests/functions/create_export.pp
@@ -51,10 +51,11 @@ define nfs::functions::create_export (
 
     if ! defined(File[$name]) {
       file { $name:
-        ensure => directory,
-        owner  => $owner,
-        group  => $group,
-        mode   => $mode,
+        ensure                  => directory,
+        owner                   => $owner,
+        group                   => $group,
+        mode                    => $mode,
+        selinux_ignore_defaults => true,
       }
     }
   }


### PR DESCRIPTION
If the source of the bind mount in an nfs v4 export is also managed by puppet then the SELinux Context is flipping between the original resource and the resource created here if they are not the same.