### PR TITLE
Fully disable bindmount

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -28,10 +28,12 @@ class nfs::server::config {
 
   if $::nfs::nfs_v4 {
 
-    concat::fragment { 'nfs_exports_root':
-      target  => $::nfs::exports_file,
-      content => "${::nfs::server::nfs_v4_export_root} ${::nfs::server::nfs_v4_export_root_clients}\n",
-      order   => 2,
+    if $::nfs::nfsv4_bindmount_enable {
+      concat::fragment { 'nfs_exports_root':
+        target  => $::nfs::exports_file,
+        content => "${::nfs::server::nfs_v4_export_root} ${::nfs::server::nfs_v4_export_root_clients}\n",
+        order   => 2,
+      }
     }
 
     if ! defined(File[$::nfs::server::nfs_v4_export_root]) {


### PR DESCRIPTION
Imagine the following configuration where one wants to configure a NFSv4 server but no bindmount...

```
class { '::nfs':
  storeconfigs_enabled       => false,
  server_enabled             => true,
  client_enabled             => false,
  nfs_v4                     => true,
  nfsv4_bindmount_enable     => false
}

$exports = { '/foo/bar' => { clients => '10.0.0.1(rw,insecure,async,no_root_squash) 10.0.0.2(rw,insecure,async,no_root_squash)' } }
create_resources('nfs::server::export', $exports, {})
```

...the module would still add a root export to /etc/exports. The following patch allows to fully disable bindmount and related features.