### PR TITLE
Added RHEL8 configuration, based off the previous "7.5 and above" config.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -228,6 +228,23 @@ class nfs::params {
           $server_nfsv4_servicehelper = [ 'nfs-idmap.service' ]
           $server_service_name        = 'nfs-server.service'
         }
+        '8': {
+          $client_idmapd_setting      = ['']
+          $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
+          $client_services_enable     = true
+          $client_gssdopt_name        = 'RPCGSSDARGS'
+          $client_services            = {'rpcbind.service' => {}}
+          $client_gssd_service_name   = { 'rpc-gssd' => {
+                                            ensure => 'running',
+                                            enable => true,
+                                          },
+                                        }
+          $client_nfsv4_fstype        = 'nfs4'
+          $client_nfsv4_options       = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
+          $client_nfsv4_services      = {'rpcbind' => {}}
+          $server_nfsv4_servicehelper = [ 'nfs-idmap.service' ]
+          $server_service_name        = 'nfs-server.service'
+        }
         default: {
           $client_gssdopt_name        = 'RPCGSSDARGS'
           $client_idmapd_setting      = ['']


### PR DESCRIPTION
Added RHEL 8 configuration.  Basically it's the same as the previous "if it's 7.5 or above" stuff.  I noticed the metadata.json already claims RHEL 8 support so I'm wondering if this is another scenario like last time where it seemed to work fine as-is for RHEL 8 for you?  Not sure, either way I had to make these tweaks to get it happy on mine.   =)