### PR TITLE
revert use of File without defined()

### DIFF
--- a/manifests/functions/create_export.pp
+++ b/manifests/functions/create_export.pp
@@ -49,7 +49,7 @@ define nfs::functions::create_export (
       content => $line,
     }
 
-    unless File[$name] {
+    unless defined(File[$name]) {
       file { $name:
         ensure                  => directory,
         owner                   => $owner,


### PR DESCRIPTION
`File['/foo/Bar']` is basically always "true" whether the resource is
defined or not.

This pr fixes #107