### PR TITLE
Archlinux clients require nfs-utils package in order to mount nfs vol…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,7 +80,7 @@ class nfs::params {
       $exports_file          = '/etc/exports'
       $idmapd_file           = '/etc/idmapd.conf'
       $server_packages       = [ 'nfs-utils' ]
-      $client_packages       = [ 'nfsidmap', 'rpcbind' ]
+      $client_packages       = [ 'nfs-utils', 'nfsidmap', 'rpcbind' ]
       $defaults_file         = undef
       $client_rpcbind_config = undef
     }


### PR DESCRIPTION
Archlinux clients require nfs-utils package in order to mount nfs voumes.

Verified on current Archlinux and Manjaro.

excerpt from nfs-uitls package listing

nfs-utils /usr/bin/mount.nfs
nfs-utils /usr/bin/mount.nfs4
