### PR TITLE
Convert legacy facts to $facts hash

### DIFF
--- a/manifests/client/service.pp
+++ b/manifests/client/service.pp
@@ -65,7 +65,7 @@ class nfs::client::service {
 
   # Redhat ~7.5 workaround (See issue https://github.com/derdanne/puppet-nfs/issues/82)
 
-  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' and versioncmp($::operatingsystemrelease, '7.5') < 0 {
+  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7' and versioncmp($facts['os']['release']['full'], '7.5') < 0 {
     transition {'stop-rpcbind.service-service':
       resource   => Service['rpcbind.service'],
       prior_to   => Service['rpcbind.socket'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,17 +33,17 @@ class nfs::params {
 
   $nfs_v4                     = false
   $nfs_v4_export_root         = '/export'
-  $nfs_v4_export_root_clients = "*.${::domain}(ro,fsid=root,insecure,no_subtree_check,async,root_squash)"
+  $nfs_v4_export_root_clients = "*.${facts['networking']['domain']}(ro,fsid=root,insecure,no_subtree_check,async,root_squash)"
   $nfs_v4_mount_root          = '/srv'
 
-  if $::domain != undef {
-    $nfs_v4_idmap_domain = $::domain
+  if $facts['networking']['domain'] != undef {
+    $nfs_v4_idmap_domain = $facts['networking']['domain']
   } else {
     $nfs_v4_idmap_domain = 'example.org'
   }
 
   # Different path and package definitions
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian': {
       $exports_file          = '/etc/exports'
       $idmapd_file           = '/etc/idmapd.conf'
@@ -91,7 +91,7 @@ class nfs::params {
       $server_packages       = undef
       $client_packages       = undef
       $client_rpcbind_config = undef
-      notice("\"${module_name}\" provides no config directory and package default values for OS family \"${::osfamily}\"")
+      notice("\"${module_name}\" provides no config directory and package default values for OS family \"${facts['os']['family']}\"")
     }
   }
 
@@ -106,7 +106,7 @@ class nfs::params {
   $server_service_hasstatus   = true
   $server_service_restart_cmd = undef
   #params with OS-specific values
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian': {
       $client_idmapd_setting      = ['set NEED_IDMAPD yes']
       $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,nfsvers=3,actimeo=3'
@@ -117,7 +117,7 @@ class nfs::params {
       $nfs_v4_idmap_nobody_group  = 'nogroup'
       $client_rpcbind_optname     = 'OPTIONS'
 
-      case $::lsbdistcodename {
+      case $facts['os']['distro']['codename'] {
         'trusty': {
           $client_services            = {'rpcbind' => {}}
           $client_nfsv4_services      = {'rpcbind' => {}, 'nfs-common' => { require => Service['rpcbind'] }}
@@ -184,13 +184,13 @@ class nfs::params {
       $nfs_v4_idmap_nobody_user   = 'nobody'
       $nfs_v4_idmap_nobody_group  = 'nobody'
       $client_rpcbind_optname     = 'RPCBIND_ARGS'
-      case $::operatingsystemmajrelease {
+      case $facts['os']['release']['major'] {
         '7': {
           $client_idmapd_setting      = ['']
           $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
           $client_services_enable     = true
           $client_gssdopt_name        = 'RPCGSSDARGS'
-          if versioncmp($::operatingsystemrelease, '7.5') < 0 {
+          if versioncmp($facts['os']['release']['full'], '7.5') < 0 {
             $client_services            = { 'rpcbind.service' => {
                                               ensure => 'running',
                                               enable => false,
@@ -211,7 +211,7 @@ class nfs::params {
                                         }
           $client_nfsv4_fstype        = 'nfs4'
           $client_nfsv4_options       = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
-          if versioncmp($::operatingsystemrelease, '7.5') < 0 {
+          if versioncmp($facts['os']['release']['full'], '7.5') < 0 {
             $client_nfsv4_services      = { 'rpcbind.service' => {
                                               ensure => 'running',
                                               enable => false,
@@ -327,7 +327,7 @@ class nfs::params {
       $server_nfsv4_servicehelper = undef
       $client_services_enable     = undef
       $server_service_name        = undef
-      notice("\"${module_name}\" provides no service parameters for OS family \"${::osfamily}\"")
+      notice("\"${module_name}\" provides no service parameters for OS family \"${facts['os']['family']}\"")
     }
   }
 }


### PR DESCRIPTION
As of Facter 3, Legacy Facts are hidden from the output of `facter` by default.  (See Legacy Fact Note near the top of the [documentation page](https://puppet.com/docs/puppet/7/core_facts.html))  The module still runs, because the facts are still accessible in the compiler.

However, when using [Onceover](https://github.com/dylanratcliffe/onceover) to test, one can generate [new/custom factsets](https://github.com/dylanratcliffe/onceover#factsets) to enable testing on a wide variety of platforms that aren't included in Onceover by default.  But because the legacy facts are no longer in the output of `facter`, they don't appear in a new custom factset, and so aren't available to Onceover.  This means that the module fails when testing using Onceover with custom factsets.

I've used `puppet-lint` to automatically convert legacy facts to $facts hash format.

I installed a few version of the facter gem all the way back to 1.1.1, and the new format facts were all present.  This change should be compatible with a wide variety of Puppet versions.