### PR TITLE
added nfsvers=3 as client_nfs_options for RedHat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -187,7 +187,7 @@ class nfs::params {
       case $facts['os']['release']['major'] {
         '7': {
           $client_idmapd_setting      = ['']
-          $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,actimeo=3'
+          $client_nfs_options         = 'tcp,nolock,rsize=32768,wsize=32768,intr,noatime,nfsvers=3,actimeo=3'
           $client_services_enable     = true
           $client_gssdopt_name        = 'RPCGSSDARGS'
           if versioncmp($facts['os']['release']['full'], '7.5') < 0 {


### PR DESCRIPTION
CentOS 7.9 mount as nfs 4 if no options are specified