### PR TITLE
change shellvar version to equal or less

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.2 < 8.0.0"},
     {"name":"puppetlabs/transition","version_requirement":">= 0.1.0 < 2.0.0"},
     {"name":"puppet/augeasproviders_core","version_requirement":">= 2.1.5 < 4.0.0"},
-    {"name":"puppet/augeasproviders_shellvar","version_requirement":">= 1.2.0 < 5.0.0"}
+    {"name":"puppet/augeasproviders_shellvar","version_requirement":">= 1.2.0 <= 5.0.0"}
   ],
   "tags": ["nfs", "nfs4", "exports", "mount", "mfc"],
   "operatingsystem_support": [


### PR DESCRIPTION
Changed version for augeasproviders_shellvar to less or equal to 5.0.0

Since this is the only version in the new repostory