### PR TITLE
Fix nfsv4_bindmount when nfs_v4_export_root includes a trailing slash

### DIFF
--- a/manifests/functions/nfsv4_bindmount.pp
+++ b/manifests/functions/nfsv4_bindmount.pp
@@ -33,7 +33,8 @@ define nfs::functions::nfsv4_bindmount (
   $bind,
   $ensure = 'mounted',
 ) {
-  $expdir = "${nfs::server::nfs_v4_export_root}/${v4_export_name}"
+  $normalize_export_root = regsubst($nfs::server::nfs_v4_export_root, '/$', '')
+  $expdir = "${normalize_export_root}/${v4_export_name}"
   nfs::functions::mkdir { $expdir:
     ensure => $ensure,
   }


### PR DESCRIPTION
If $nfs::server::nfs_v4_export_root ends with a trailing slash, or is simply equal to '/', Puppet thinks the bindmounts are not mounted and try to mount them at each apply.