### PR TITLE
fix: update puppet versions to 6.29.0 and 7.22.0 in spec tests

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        puppet: [7.20.0]
+        puppet: [7.22.0]
         ruby: [2.7.7, 3.0.5, 3.1.3]
 
     name: Static code analysis
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        puppet: [5.5.22, 6.28.0]
+        puppet: [5.5.22, 6.29.0]
         ruby: [2.5.9, 2.6.9]
 
     name: Static code analysis


### PR DESCRIPTION
resolve NameError: uninitialized constant Concurrent::RubyThreadLocalVar