### PR TITLE
feat: add a parameter to define if we manage nfs server service ensure state

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,10 @@
 #   String. It defines the servicename of the nfs server service
 #
 # [*server_service_ensure*]
-#   Boolean. It defines the service parameter ensure for nfs server services.
+#   Enum. It defines the service parameter ensure for nfs server services.
+#
+# [*manage_server_service_ensure*]
+#   Boolean. It defines if the nfs server service ensure state should be managed.
 #
 # [*server_service_enable*]
 #   Boolean. It defines the service parameter enable for nfs server service.
@@ -228,6 +231,7 @@ class nfs(
   Boolean $manage_server_servicehelper                                                = true,
   Boolean $manage_client_service                                                      = true,
   String $server_service_name                                                         = $::nfs::params::server_service_name,
+  Boolean $manage_server_service_ensure                                               = true,
   Enum['present', 'absent', 'running', 'stopped', 'disabled'] $server_service_ensure  = 'running',
   Boolean $server_service_enable                                                      = true,
   Boolean $server_service_hasrestart                                                  = $::nfs::params::server_service_hasrestart,

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -18,6 +18,12 @@ class nfs::server::service {
 
   if $::nfs::nfs_v4 == true {
 
+    if $::nfs::manage_server_service_ensure {
+      $server_service_ensure_real = $::nfs::server_service_ensure
+    } else {
+      $server_service_ensure_real = undef
+    }
+
     if $::nfs::server_nfsv4_servicehelper != undef and $::nfs::manage_server_servicehelper {
       $server_service_require = Service[$::nfs::server_nfsv4_servicehelper]
       $::nfs::server_nfsv4_servicehelper.each |$service_name| {
@@ -35,7 +41,7 @@ class nfs::server::service {
 
     if $::nfs::manage_server_service {
       service { $::nfs::server_service_name:
-        ensure     => $::nfs::server_service_ensure,
+        ensure     => $server_service_ensure_real,
         enable     => $::nfs::server_service_enable,
         hasrestart => $::nfs::server_service_hasrestart,
         hasstatus  => $::nfs::server_service_hasstatus,
@@ -48,7 +54,7 @@ class nfs::server::service {
 
     if $::nfs::manage_server_service {
       service { $::nfs::server_service_name:
-        ensure     => $::nfs::server_service_ensure,
+        ensure     => $server_service_ensure_real,
         enable     => $::nfs::server_service_enable,
         hasrestart => $::nfs::server_service_hasrestart,
         hasstatus  => $::nfs::server_service_hasstatus,


### PR DESCRIPTION
We want puppet-nfs to manage the NFS service but not manage the service state (running/stopped) because that state is managed by another tool.