### PR TITLE
🔥 remove EOL SLES/OpenSUSE version and ✨ add currrent SLES/OpenSUSE version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -82,13 +82,13 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "12"
+        "15"
       ]
     },
     {
       "operatingsystem": "openSUSE",
       "operatingsystemrelease": [
-        "13"
+        "15"
       ]
     }
   ],


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes already end-of-life SLES12/OpenSUSE13 and adds current SLES15/OpenSUSE15.

#### This Pull Request (PR) fixes the following issues
There's no issue for this PR.

