### PR TITLE
Drop EOL Ubuntu 20.04, RedHat 7, CentOS 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04",
         "24.04"
       ]
@@ -56,7 +55,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9",
         "10"
@@ -65,7 +63,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "8",
         "9",
         "10"
       ]


### PR DESCRIPTION
#229 and #194 remove code and data related to these EOL operating systems.