### PR TITLE
`metadata.json`: remove `augeas_core` and `mount_core`

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,14 +27,6 @@
     {
       "name": "puppet/augeasproviders_shellvar",
       "version_requirement": ">= 1.2.0 <= 7.0.0"
-    },
-    {
-      "name": "puppetlabs/augeas_core",
-      "version_requirement": ">= 1.2.0 <= 2.0.0"
-    },
-    {
-      "name": "puppetlabs/mount_core",
-      "version_requirement": ">= 1.2.0 <= 2.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
We don't list puppetlabs core modules in the `metadata.json` dependency list since those modules are included in Puppet and OpenVox packages.
