### PR TITLE
README: fix resource creation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ node server {
 
   $nfs_exports_global.each |$k, $v| {
     nfs::server::export { $k:
-      * => $defaults_nfs_exports,
+      * => $defaults_nfs_exports + $v,
     }
   }
 }


### PR DESCRIPTION
Missed this in 3787c96c68447960413d5eb80c6e17a77a6be7c3.
