### PR TITLE
Fix missing `nfs_v4_export_root` in share path for NFSv4 exports

### DIFF
--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -130,7 +130,7 @@ define nfs::server::export (
         options_nfsv4 => $options_nfsv4,
         bindmount     => $bindmount,
         nfstag        => $nfstag,
-        share         => $export_name,
+        share         => $export_title,
         server        => $server,
       }
     }


### PR DESCRIPTION
Use export_title to include nfs::server::nfs_v4_export_root as prefix

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fix missing nfs::server::nfs_v4_export_root in nfs4 export mount point


#### This Pull Request (PR) fixes the following issues
Fixes #245 

