### PR TITLE
Revert "Allow client mount to override fstype"

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -798,7 +798,6 @@ The following parameters are available in the `nfs::client::mount` defined type:
 * [`mount_root`](#-nfs--client--mount--mount_root)
 * [`umask`](#-nfs--client--mount--umask)
 * [`mount`](#-nfs--client--mount--mount)
-* [`fstype`](#-nfs--client--mount--fstype)
 * [`manage_packages`](#-nfs--client--mount--manage_packages)
 * [`client_packages`](#-nfs--client--mount--client_packages)
 * [`nfs_v4`](#-nfs--client--mount--nfs_v4)
@@ -920,14 +919,6 @@ Data type: `String[1]`
 
 
 Default value: `$title`
-
-##### <a name="-nfs--client--mount--fstype"></a>`fstype`
-
-Data type: `String[1]`
-
-Set 'fstype' for the mount
-
-Default value: `$nfs::client_nfsv4_fstype`
 
 ##### <a name="-nfs--client--mount--manage_packages"></a>`manage_packages`
 

--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -46,8 +46,6 @@
 #   Set umask for mount directory creation.
 #
 # @param mount
-# @param fstype
-#   Set 'fstype' for the mount
 # @param manage_packages
 # @param client_packages
 # @param nfs_v4
@@ -74,7 +72,6 @@ define nfs::client::mount (
   String[1]                                      $server,
   Optional[String[1]]                            $share           = undef,
   String[1]                                      $ensure          = 'mounted',
-  String[1]                                      $fstype          = $nfs::client_nfsv4_fstype,
   String[1]                                      $mount           = $title,
   Boolean                                        $remounts        = false,
   Boolean                                        $atboot          = false,
@@ -118,7 +115,7 @@ define nfs::client::mount (
     mount { "shared ${sharename} by ${server} on ${mount}":
       ensure   => $ensure,
       device   => "${server}:${sharename}",
-      fstype   => $fstype,
+      fstype   => $nfs::client_nfsv4_fstype,
       name     => $mount,
       options  => $options_nfsv4,
       remounts => $remounts,
@@ -146,7 +143,7 @@ define nfs::client::mount (
     mount { "shared ${sharename} by ${server} on ${mount}":
       ensure   => $ensure,
       device   => "${server}:${sharename}",
-      fstype   => $fstype,
+      fstype   => $nfs::client_nfs_fstype,
       name     => $mount,
       options  => $options_nfs,
       remounts => $remounts,

--- a/spec/defines/client_mount_spec.rb
+++ b/spec/defines/client_mount_spec.rb
@@ -71,7 +71,7 @@ describe 'nfs::client::mount', type: 'define' do
         it { is_expected.to contain_nfs__functions__mkdir('/srv/test') }
 
         it do
-          is_expected.to contain_mount('shared /test by 1.2.3.4 on /srv/test').with(fstype: 'nfs4').that_requires(
+          is_expected.to contain_mount('shared /test by 1.2.3.4 on /srv/test').that_requires(
             [
               'Nfs::Functions::Mkdir[/srv/test]',
             ] + client_packages,
@@ -90,7 +90,7 @@ describe 'nfs::client::mount', type: 'define' do
         it { is_expected.to contain_mount('shared /test by 1.2.3.4 on /srv/test') }
 
         it do
-          is_expected.to contain_mount('shared /test by 1.2.3.4 on /srv/test').with(fstype: 'nfs4').that_requires(
+          is_expected.to contain_mount('shared /test by 1.2.3.4 on /srv/test').that_requires(
             [
               'Nfs::Functions::Mkdir[/srv/test]',
             ] + client_packages,
@@ -108,7 +108,7 @@ describe 'nfs::client::mount', type: 'define' do
         it { is_expected.to contain_nfs__functions__mkdir('/opt/sample') }
 
         it do
-          is_expected.to contain_mount('shared /test by 1.2.3.4 on /opt/sample').with(fstype: 'nfs4').that_requires(
+          is_expected.to contain_mount('shared /test by 1.2.3.4 on /opt/sample').that_requires(
             [
               'Nfs::Functions::Mkdir[/opt/sample]',
             ] + client_packages,
@@ -126,7 +126,7 @@ describe 'nfs::client::mount', type: 'define' do
         it { is_expected.to contain_nfs__functions__mkdir('/opt/sample') }
 
         it do
-          is_expected.to contain_mount('shared /test by 1.2.3.4 on /opt/sample').with(fstype: 'nfs4').that_requires(
+          is_expected.to contain_mount('shared /test by 1.2.3.4 on /opt/sample').that_requires(
             [
               'Nfs::Functions::Mkdir[/opt/sample]',
             ],
@@ -147,26 +147,6 @@ describe 'nfs::client::mount', type: 'define' do
 
         it do
           is_expected.to contain_mount('shared /srv/test by 1.2.3.4 on /srv/test').that_requires(
-            [
-              'Nfs::Functions::Mkdir[/srv/test]',
-            ] + client_packages,
-          )
-        end
-      end
-
-      context 'when nfs_v4 => false, fstype set' do
-        let(:title) { '/srv/test' }
-
-        let(:pre_condition) { 'class { "nfs": client_enabled => true }' }
-
-        let(:params) { { server: '1.2.3.4', fstype: 'nfs' } }
-
-        it { is_expected.to contain_nfs__functions__mkdir('/srv/test') }
-
-        it { is_expected.to contain_exec('mkdir_recurse_/srv/test').with(command: 'mkdir -p /srv/test') }
-
-        it do
-          is_expected.to contain_mount('shared /srv/test by 1.2.3.4 on /srv/test').with(fstype: 'nfs').that_requires(
             [
               'Nfs::Functions::Mkdir[/srv/test]',
             ] + client_packages,


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
This reverts commit 8b8a9177115cb0daa07ea969070d33e1341f6c73.

This would cause issues for NFSv3 clients where "nfs::client_nfs_fstype" is set.
